### PR TITLE
All attributes from lv api

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ template:
       - name: "In Demand Interval"
         unique_id: "demand_interval"
         state: >
-          {{ state_attr('sensor.costsflexup', 'demandInterval') | int == 1 }}
+          {{ state_attr('sensor.intervalend', 'demandInterval') | int == 1 }}
         icon: mdi:clock
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,22 @@
 # Localvolts
 An integration for Home Assistant for customers of Localvolts electricity retailer in Australia
 
-The integration exposes three sensors...
+The integration currently exposes four sensors...
 
 1) costsFlexUp is the current IMPORT cost of electricity FOR YOU per kWh until the end of the current 5 minute interval.
 It's essentially the marginal cost of electricity for you and includes loss factors and network fees associated with increasing your consumption by 1kW right now.
 Of course, this only lasts until the end of the 5 minute interval, during which you would only have pulled that extra 1kW for 5 minutes which is a total energy of 1/12 kWh = 0.083kWh
 
-This costsFlexUp sensor also has an attribute for 'DemandInterval' reflecting whether the current 5-minute interval is within the time window for a Demand Tariff to be active.
-NOTE: to use this in a sensor, you should integrate the following code to your configuration.yaml.
+NOTE: If you are using the DemandInterval attribute of this sensor, please switch to the IntervalEnd sensor's attribute of the same name. The DemandInterval attribute will be deprecated from this sensor in a future release to clean up the code.
+
+2) earningsFlexUp is the current EXPORT price of electricity FOR YOU per additional kWh exported until the end of the current 5 minute interval.
+
+3) datalag which is the duration within the current 5 min interval before new data was discovered with the Localvolts API.  This is usually (hopefully) within 30 seconds and can be as low as 15 seconds.
+
+4) intervalEnd contains attributes for all of the data from the Localvolts API for the current 5 minute interval.
+
+For example, use the following code in your configuration.yaml to access the attribute for 'DemandInterval' (reflecting whether the current 5-minute interval is within the time window for a Demand Tariff to be active).
+
 ```
 template:
   - binary_sensor:
@@ -18,10 +26,6 @@ template:
           {{ state_attr('sensor.costsflexup', 'demandInterval') | int == 1 }}
         icon: mdi:clock
 ```
-
-2) earningsFlexUp is the current EXPORT price of electricity FOR YOU per additional kWh exported until the end of the current 5 minute interval.
-
-3) datalag which is the duration within the current 5 min interval before new data was discovered with the Localvolts API.  This is usually (hopefully) within 30 seconds and can be as low as 15 seconds.
 
 To use this integration in Home Assistant, it is necessary to join Localvolts as a customer https://localvolts.com/register/
 and request an API key using this form https://localvolts.com/localvolts-api/

--- a/custom_components/localvolts/manifest.json
+++ b/custom_components/localvolts/manifest.json
@@ -10,5 +10,5 @@
   "codeowners": ["@gurrier"],
   "requirements": ["requests>=2.25.1"],
   "config_flow": true,
-  "version": "0.5.1"
+  "version": "0.5.3"
 }

--- a/custom_components/localvolts/sensor.py
+++ b/custom_components/localvolts/sensor.py
@@ -1,23 +1,21 @@
-
 """Platform for Localvolts sensor integration."""
 
 from __future__ import annotations
 
 import logging
+from typing import Any
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
     SensorEntity,
 )
-
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DOMAIN
-
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
+from .const import DOMAIN
 from .coordinator import LocalvoltsDataUpdateCoordinator
 
 MONETARY_CONVERSION_FACTOR = 100
@@ -27,13 +25,13 @@ EARNINGS_FLEX_UP = "earningsFlexUp"
 
 _LOGGER = logging.getLogger(__name__)
 
+
 async def async_setup_entry(
     hass: HomeAssistant,
     config_entry: ConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up Localvolts sensors from a config entry."""
-
     coordinator = hass.data[DOMAIN]['coordinator']
 
     async_add_entities(
@@ -41,36 +39,35 @@ async def async_setup_entry(
             LocalvoltsCostsFlexUpSensor(coordinator),
             LocalvoltsEarningsFlexUpSensor(coordinator),
             LocalvoltsDataLagSensor(coordinator),
+            LocalvoltsIntervalEndSensor(coordinator),
         ]
     )
 
-class LocalvoltsSensor(CoordinatorEntity, SensorEntity):
-    """Representation of a Localvolts Sensor."""
 
-    def __init__(self, coordinator: LocalvoltsDataUpdateCoordinator, data_key: str):
-        """Initialize the sensor."""
+class LocalvoltsSensor(CoordinatorEntity, SensorEntity):
+    """Representation of a generic Localvolts sensor."""
+
+    def __init__(self, coordinator: LocalvoltsDataUpdateCoordinator, data_key: str) -> None:
         super().__init__(coordinator)
         self.data_key = data_key
-        self._attr_should_poll = False  # DataUpdateCoordinator handles updates
-        self._last_value = None  # Store the last known value
+        self._attr_should_poll = False
+        self._last_value = None
 
     @property
     def native_value(self):
-        """Return the state of the sensor."""
+        """Return the state of the sensor (scaled monetary value)."""
         item = self.coordinator.data
         if item:
             value = item.get(self.data_key)
             if value is not None:
                 self._last_value = round(value / MONETARY_CONVERSION_FACTOR, 3)
-        # Return the last known value even if item is None or value is None
         return self._last_value
 
     @property
     def extra_state_attributes(self):
-        """Return additional state attributes."""
+        """Return basic interval attributes (intervalEnd and lastUpdate)."""
         interval_end = self.coordinator.intervalEnd
         last_update = self.coordinator.lastUpdate
-
         return {
             "intervalEnd": interval_end.isoformat() if interval_end else None,
             "lastUpdate": last_update.isoformat() if last_update else None,
@@ -83,21 +80,20 @@ class LocalvoltsCostsFlexUpSensor(LocalvoltsSensor):
     _attr_native_unit_of_measurement = "$/kWh"
     _attr_device_class = SensorDeviceClass.MONETARY
 
-    def __init__(self, coordinator):
-        """Initialize the costsFlexUp sensor."""
+    def __init__(self, coordinator: LocalvoltsDataUpdateCoordinator) -> None:
         super().__init__(coordinator, COSTS_FLEX_UP)
         self._attr_name = COSTS_FLEX_UP
         self._attr_unique_id = f"{coordinator.nmi_id}_{COSTS_FLEX_UP}"
 
     @property
     def extra_state_attributes(self):
-        # Start with the base attributes defined in LocalvoltsSensor
+        """Extend base attributes with demandInterval if available."""
         attributes = super().extra_state_attributes
-        # Add the 'demandInterval' attribute if it's available in the coordinator data
         demand_interval = self.coordinator.data.get("demandInterval")
         if demand_interval is not None:
             attributes["demandInterval"] = demand_interval
         return attributes
+
 
 class LocalvoltsEarningsFlexUpSensor(LocalvoltsSensor):
     """Sensor for monitoring earningsFlexUp."""
@@ -105,41 +101,78 @@ class LocalvoltsEarningsFlexUpSensor(LocalvoltsSensor):
     _attr_native_unit_of_measurement = "$/kWh"
     _attr_device_class = SensorDeviceClass.MONETARY
 
-    def __init__(self, coordinator):
-        """Initialize the earningsFlexUp sensor."""
+    def __init__(self, coordinator: LocalvoltsDataUpdateCoordinator) -> None:
         super().__init__(coordinator, EARNINGS_FLEX_UP)
         self._attr_name = EARNINGS_FLEX_UP
         self._attr_unique_id = f"{coordinator.nmi_id}_{EARNINGS_FLEX_UP}"
 
 
 class LocalvoltsDataLagSensor(CoordinatorEntity, SensorEntity):
-    """Sensor for monitoring the data lag time."""
+    """Sensor for monitoring the data lag time in seconds."""
 
-    _attr_native_unit_of_measurement = "s"  # Seconds
+    _attr_native_unit_of_measurement = "s"
     _attr_device_class = SensorDeviceClass.DURATION
 
-    def __init__(self, coordinator):
-        """Initialize the DataLag sensor."""
+    def __init__(self, coordinator: LocalvoltsDataUpdateCoordinator) -> None:
         super().__init__(coordinator)
-        self._attr_name = "DataLag"  # Updated sensor name
+        self._attr_name = "DataLag"
         self._attr_unique_id = f"{coordinator.nmi_id}_data_lag"
         self._attr_should_poll = False
 
     @property
     def native_value(self):
-        """Return the state of the sensor."""
+        """Return the duration since the interval started, in seconds."""
         time_past_start = self.coordinator.time_past_start
-        if time_past_start is not None:
-            return time_past_start.total_seconds()
-        return None
+        return time_past_start.total_seconds() if time_past_start else None
 
     @property
     def extra_state_attributes(self):
-        """Return additional state attributes."""
+        """Return basic interval attributes for data lag."""
         interval_end = self.coordinator.intervalEnd
         last_update = self.coordinator.lastUpdate
-
         return {
             "intervalEnd": interval_end.isoformat() if interval_end else None,
             "lastUpdate": last_update.isoformat() if last_update else None,
         }
+
+
+class LocalvoltsIntervalEndSensor(CoordinatorEntity, SensorEntity):
+    """Sensor for monitoring the end time of the latest interval."""
+
+    _attr_device_class = SensorDeviceClass.TIMESTAMP
+
+    def __init__(self, coordinator: LocalvoltsDataUpdateCoordinator) -> None:
+        super().__init__(coordinator)
+        self._attr_name = "IntervalEnd"
+        self._attr_unique_id = f"{coordinator.nmi_id}_interval_end"
+        self._attr_should_poll = False
+
+    @property
+    def native_value(self):
+        """Return the interval end as a datetime object."""
+        return self.coordinator.intervalEnd
+
+    @property
+    def extra_state_attributes(self):
+        """
+        Return all available interval fields as attributes.
+
+        This method copies every key/value pair from the coordinator's data dictionary,
+        converting any datetime objects to ISO strings for readability.  It then adds
+        the `lastUpdate` and `intervalEnd` timestamps (converted to ISO strings) so
+        that these are always present.
+        """
+        attrs: dict[str, Any] = {}
+        data = getattr(self.coordinator, "data", {}) or {}
+        # Copy all fields from the data record
+        for key, value in data.items():
+            if hasattr(value, "isoformat"):
+                attrs[key] = value.isoformat()
+            else:
+                attrs[key] = value
+        # Ensure lastUpdate and intervalEnd are included as ISO strings
+        if getattr(self.coordinator, "lastUpdate", None):
+            attrs["lastUpdate"] = self.coordinator.lastUpdate.isoformat()
+        if getattr(self.coordinator, "intervalEnd", None):
+            attrs["intervalEnd"] = self.coordinator.intervalEnd.isoformat()
+        return attrs

--- a/hacs.json
+++ b/hacs.json
@@ -1,7 +1,7 @@
 {
   "name": "Localvolts Integration",
   "documentation": "https://github.com/gurrier/localvolts",
-  "version": "0.5.1",
+  "version": "0.5.3",
   "render_readme": true,
   "content_in_root": false,
   "category": "integration"


### PR DESCRIPTION
The Home Asistant integration now exposes a sensor called IntervalEnd which contains attributes of all the fields returned by the Localvolts API for the currnet 5 minute interval.
The Readme explains how to access them and recommends replacing the costFlexUp sensor's attribute of DemandInterval before it is deprecated.