### PR TITLE
Replace requests with python-dateutil requirement

### DIFF
--- a/custom_components/localvolts/manifest.json
+++ b/custom_components/localvolts/manifest.json
@@ -8,7 +8,7 @@
   "iot_class": "cloud_polling",
   "dependencies": [],
   "codeowners": ["@gurrier"],
-  "requirements": ["requests>=2.25.1"],
+  "requirements": ["python-dateutil>=2.8"],
   "config_flow": true,
   "version": "0.5.3"
 }


### PR DESCRIPTION
## Summary
- remove requests from integration requirements
- add python-dateutil to support dateutil usage

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a685fc33d483338289d683a5fe6993