### PR TITLE
Add translation labels for Localvolts configuration and options

### DIFF
--- a/custom_components/localvolts/translations/en.json
+++ b/custom_components/localvolts/translations/en.json
@@ -4,16 +4,36 @@
         "step": {
             "user": {
                 "title": "Add NMI",
-                "description": "Set up the NMI for your Localvolts integration."
+                "description": "Set up the NMI for your Localvolts integration.",
+                "data": {
+                    "api_key": "API Key",
+                    "partner_id": "Partner ID",
+                    "nmi_id": "NMI ID"
+                }
             }
+        },
+        "error": {
+            "invalid_api_key": "Invalid API key",
+            "invalid_partner_id": "Invalid partner ID",
+            "invalid_nmi_id": "Invalid NMI ID"
         }
     },
     "options": {
         "step": {
             "init": {
                 "title": "Localvolts Options",
-                "description": "Options for the Localvolts integration."
+                "description": "Options for the Localvolts integration.",
+                "data": {
+                    "api_key": "API Key",
+                    "partner_id": "Partner ID",
+                    "nmi_id": "NMI ID"
+                }
             }
+        },
+        "error": {
+            "invalid_api_key": "Invalid API key",
+            "invalid_partner_id": "Invalid partner ID",
+            "invalid_nmi_id": "Invalid NMI ID"
         }
     },
     "title": "Localvolts",


### PR DESCRIPTION
## Summary
- add API key, partner ID, and NMI ID labels to config flow
- add error messages for invalid API key, partner ID, and NMI ID
- mirror labels and errors in options flow

## Testing
- `python - <<'PY'
import json; json.load(open('custom_components/localvolts/translations/en.json'))
print('JSON valid')
PY`
- `pytest -q`
- `pre-commit run --files custom_components/localvolts/translations/en.json` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a68c4e875483339379ff9b488c2052