### PR TITLE
Declare minimum Home Assistant version

### DIFF
--- a/custom_components/localvolts/manifest.json
+++ b/custom_components/localvolts/manifest.json
@@ -10,5 +10,6 @@
   "codeowners": ["@gurrier"],
   "requirements": ["python-dateutil>=2.8"],
   "config_flow": true,
-  "version": "0.5.3"
+  "version": "0.5.3",
+  "homeassistant": "2023.12.0"
 }


### PR DESCRIPTION
## Summary
- specify minimum supported Home Assistant release in the integration manifest

## Testing
- `python -m json.tool custom_components/localvolts/manifest.json`
- `pre-commit run --files custom_components/localvolts/manifest.json` *(fails: command not found)*
- `pip install pre-commit` *(fails: no matching distribution due to proxy restrictions)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a6a36e158883339f12c725447d0418