### PR TITLE
fix: add missing comma in hacs.json

### DIFF
--- a/hacs.json
+++ b/hacs.json
@@ -4,7 +4,7 @@
   "version": "0.5.3",
   "render_readme": true,
   "content_in_root": false,
-  "category": "integration"
+  "category": "integration",
   "icon": "assets/localvolts_icon.png",
   "logo": "assets/localvolts_logo.png"
 }


### PR DESCRIPTION
## Summary
- add missing comma after the category line in `hacs.json`

## Testing
- `python -m json.tool hacs.json`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a6a628ce608333a02576cd07380b6e