### PR TITLE
Added 24 hour data from Localvolts in 5 minute forecast intervals

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Localvolts
 An integration for Home Assistant for customers of Localvolts electricity retailer in Australia
 
-The integration currently exposes four sensors...
+The integration currently exposes five sensors...
 
 1) costsFlexUp is the current IMPORT cost of electricity FOR YOU per kWh until the end of the current 5 minute interval.
 It's essentially the marginal cost of electricity for you and includes loss factors and network fees associated with increasing your consumption by 1kW right now.
@@ -14,6 +14,34 @@ NOTE: If you are using the DemandInterval attribute of this sensor, please switc
 3) datalag which is the duration within the current 5 min interval before new data was discovered with the Localvolts API.  This is usually (hopefully) within 30 seconds and can be as low as 15 seconds.
 
 4) intervalEnd contains attributes for all of the data from the Localvolts API for the current 5 minute interval.
+
+5) forecasted_costs_flex_up state reflects current costsFlexUp in c/kWh. State attributes capture 5 minute forcasts for earningFlexUp and costsFlexUp in c/kWh. Also captures forcastcount (total forecasts in list)
+
+```
+forecast:
+  - duration: 5
+    start_time: "2025-09-01T21:55:00+00:00"
+    end_time: "2025-09-01T22:00:00+00:00"
+    earningsFlexUp: 22.65218
+    costsFlexUp: 32.34263
+  - duration: 5
+    start_time: "2025-09-01T22:00:00+00:00"
+    end_time: "2025-09-01T22:05:00+00:00"
+    earningsFlexUp: 20.38499
+    costsFlexUp: 29.84872
+  ...
+  - duration: 5
+    start_time: '2025-09-02T21:50:00+00:00'
+    end_time: '2025-09-02T21:55:00+00:00'
+    earningsFlexUp: 12.81728
+    costsFlexUp: 21.52423
+
+  forecastcount: 287
+  unit_of_measurement: c/kWh
+  device_class: monetary
+  friendly_name: Forecasted Costs Flex Up
+```
+
 
 For example, use the following code in your configuration.yaml to access the attribute for 'DemandInterval' (reflecting whether the current 5-minute interval is within the time window for a Demand Tariff to be active).
 

--- a/custom_components/localvolts/config_flow.py
+++ b/custom_components/localvolts/config_flow.py
@@ -5,83 +5,79 @@ from homeassistant import config_entries
 from homeassistant.core import callback
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.selector import selector
 
 from .const import DOMAIN, CONF_API_KEY, CONF_PARTNER_ID, CONF_NMI_ID
 from . import validate_api_key, validate_partner_id, validate_nmi_id
 
 _LOGGER = logging.getLogger(__name__)
-
-# Define the schema with placeholders for default values
-def build_data_schema(existing_data):
-    return vol.Schema(
-        {
-            vol.Required(CONF_API_KEY, default=existing_data.get(CONF_API_KEY, "")): cv.string,
-            vol.Required(CONF_PARTNER_ID, default=existing_data.get(CONF_PARTNER_ID, "")): cv.string,
-            vol.Required(CONF_NMI_ID, default=existing_data.get(CONF_NMI_ID, "")): cv.string,
-        }
-    )
-
+    
 class LocalvoltsConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
-    """Handle a config flow for the Localvolts integration."""
-
     VERSION = 1
 
-    async def async_step_user(self, user_input=None) -> FlowResult:
-        """Handle the initial step."""
+    async def async_step_user(self, user_input=None):
         errors = {}
-
-        # If this is a reconfiguration, pre-populate with existing data
-        existing_entry = next(iter(self._async_current_entries()), None)
-        existing_data = existing_entry.data if existing_entry else {}
-
-        #_LOGGER.debug("Existing data: %s", existing_data)
-
         if user_input is not None:
-            # Validate the inputs
-            if not validate_api_key(user_input[CONF_API_KEY]):
-                errors[CONF_API_KEY] = "invalid_api_key"
-            elif not validate_partner_id(user_input[CONF_PARTNER_ID]):
-                errors[CONF_PARTNER_ID] = "invalid_partner_id"
-            elif not validate_nmi_id(user_input[CONF_NMI_ID]):
-                errors[CONF_NMI_ID] = "invalid_nmi_id"
+            # Validate required fields
+            api_key = user_input.get("api_key")
+            partner_id = user_input.get("partner_id")
+            nmi_id = user_input.get("nmi_id")
+
+            if not api_key:
+                errors["api_key"] = "required"
+            if not partner_id:
+                errors["partner_id"] = "required"
+            if not nmi_id:
+                errors["nmi_id"] = "required"
 
             if not errors:
-                # Use the NMI_ID as the title of the integration
-                title = f"NMI: {user_input[CONF_NMI_ID]}"
-                # Save the configuration and create the entry
-                return self.async_create_entry(title=title, data=user_input)
-                
-        # Show the form if there are errors or if the user input is None
-        return self.async_show_form(
-            step_id="user", data_schema=build_data_schema(existing_data), errors=errors
-        )
+                return self.async_create_entry(title="LocalVolts", data=user_input)
 
+        return self.async_show_form(
+            step_id="user",
+            data_schema=vol.Schema({
+                vol.Required("api_key", default=(user_input or {}).get("api_key", "")): str,
+                vol.Required("partner_id", default=(user_input or {}).get("partner_id", "")): str,
+                vol.Required("nmi_id", default=(user_input or {}).get("nmi_id", "")): str,
+            }),
+            errors=errors,
+        )
+        
     @staticmethod
     @callback
     def async_get_options_flow(config_entry):
         return LocalvoltsOptionsFlowHandler(config_entry)
 
 class LocalvoltsOptionsFlowHandler(config_entries.OptionsFlow):
-    """Handle options for the Localvolts integration."""
-
     def __init__(self, config_entry):
-        """Initialize Localvolts options flow."""
-        super().__init__(config_entry)
+        self.config_entry = config_entry
 
-    async def async_step_init(self, user_input=None) -> FlowResult:
-        """Manage the options."""
-        return await self.async_step_user(user_input)
-
-    async def async_step_user(self, user_input=None) -> FlowResult:
-        """Handle the options step."""
+    async def async_step_init(self, user_input=None):
         errors = {}
-
         if user_input is not None:
-            # Save the updated options
-            return self.async_create_entry(title="", data=user_input)
+            api_key = user_input.get("api_key")
+            partner_id = user_input.get("partner_id")
+            nmi_id = user_input.get("nmi_id")
 
-        # Pre-populate with existing options
-        options = self.config_entry.options
+            if not api_key:
+                errors["api_key"] = "required"
+            if not partner_id:
+                errors["partner_id"] = "required"
+            if not nmi_id:
+                errors["nmi_id"] = "required"
+
+            if not errors:
+                return self.async_create_entry(title="", data=user_input)
+
+        # Use current options or entry data as defaults
+        cur = {**self.config_entry.data, **self.config_entry.options}
+
         return self.async_show_form(
-            step_id="user", data_schema=build_data_schema(options), errors=errors
+            step_id="init",
+            data_schema=vol.Schema({
+                vol.Required("api_key", default=(user_input or {}).get("api_key", cur.get("api_key", ""))): str,
+                vol.Required("partner_id", default=(user_input or {}).get("partner_id", cur.get("partner_id", ""))): str,
+                vol.Required("nmi_id", default=(user_input or {}).get("nmi_id", cur.get("nmi_id", ""))): str,
+            }),
+            errors=errors,
         )

--- a/custom_components/localvolts/coordinator.py
+++ b/custom_components/localvolts/coordinator.py
@@ -11,6 +11,7 @@ from homeassistant.helpers.update_coordinator import (
     UpdateFailed,
 )
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from .const import DOMAIN
 
 import aiohttp
 
@@ -18,33 +19,24 @@ _LOGGER = logging.getLogger(__name__)
 
 SCAN_INTERVAL = datetime.timedelta(seconds=10)  # Update every 10 seconds
 
+
 class LocalvoltsDataUpdateCoordinator(DataUpdateCoordinator):
     """DataUpdateCoordinator to manage fetching data from Localvolts API."""
 
-    #def __init__(self, hass: HomeAssistant, api_key, partner_id, nmi_id):
     def __init__(
         self,
-        hass: HomeAssistant,
-        api_key: str,
-        partner_id: str,
-        nmi_id: str,
+        hass
     ) -> None:
         """Initialize the coordinator."""
-        #self.api_key = api_key
-        #self.partner_id = partner_id
-        #self.nmi_id = nmi_id
-        #self.intervalEnd = None
-        #self.lastUpdate = None
-        #self.time_past_start = datetime.timedelta(0)
-        #self.data = {}
-        self.api_key: str = api_key
-        self.partner_id: str = partner_id
-        self.nmi_id: str = nmi_id
+        self.hass = hass
+        self.api_key: str = self.hass.data[DOMAIN]["api_key"]
+        self.partner_id = self.hass.data[DOMAIN]["partner_id"]
+        self.nmi_id: str = self.hass.data[DOMAIN]["nmi_id"]
         self.intervalEnd: Any = None
         self.lastUpdate: Any = None
         self.time_past_start: datetime.timedelta = datetime.timedelta(0)
         self.data: Dict[str, Any] = {}
-
+        self.forecast_data: List[Dict[str, Any]] = []
 
         super().__init__(
             hass,
@@ -54,10 +46,14 @@ class LocalvoltsDataUpdateCoordinator(DataUpdateCoordinator):
         )
 
     async def _async_update_data(self) -> Dict[str, Any]:
+        api_key: str = self.hass.data[DOMAIN]["api_key"]
+        partner_id = self.hass.data[DOMAIN]["partner_id"]
+        nmi_id: str = self.hass.data[DOMAIN]["nmi_id"]
         """Fetch data from the API endpoint."""
-        current_utc_time: datetime.datetime = datetime.datetime.now(datetime.timezone.utc)
+        current_utc_time: datetime.datetime = datetime.datetime.now(
+            datetime.timezone.utc)
         from_time: datetime.datetime = current_utc_time
-        to_time: datetime.datetime = current_utc_time + datetime.timedelta(minutes=5)
+        to_time: datetime.datetime = current_utc_time + datetime.timedelta(hours=24) - datetime.timedelta(minutes=5)
 
         _LOGGER.debug("intervalEnd = %s", self.intervalEnd)
         _LOGGER.debug("lastUpdate = %s", self.lastUpdate)
@@ -72,26 +68,22 @@ class LocalvoltsDataUpdateCoordinator(DataUpdateCoordinator):
 
             url: str = (
                 f"https://api.localvolts.com/v1/customer/interval?"
-                f"NMI={self.nmi_id}&from={from_time_str}&to={to_time_str}"
+                f"NMI={nmi_id}&from={from_time_str}&to={to_time_str}"
             )
 
             headers: Dict[str, str] = {
-                "Authorization": f"apikey {self.api_key}",
-                "partner": self.partner_id,
+                "Authorization": f"apikey {api_key}",
+                "partner": partner_id,
             }
 
             try:
-            #    async with aiohttp.ClientSession() as session:
-            #        async with session.get(url, headers=headers) as response:
-            #            response.raise_for_status()
-            #            data = await response.json()
-                # Use Home Assistant's managed session
-                #session = self.hass.helpers.aiohttp_client.async_get_clientsession()
                 session = async_get_clientsession(self.hass)
                 async with session.get(url, headers=headers) as response:
                     if response.status == 401:
-                        _LOGGER.critical("Unauthorized access: Check your API key.")
-                        raise UpdateFailed("Unauthorized access: Invalid API key.")
+                        _LOGGER.critical(
+                            "Unauthorized access: Check your API key.")
+                        raise UpdateFailed(
+                            "Unauthorized access: Invalid API key.")
                     elif response.status == 403:
                         _LOGGER.critical("Forbidden: Check your Partner ID.")
                         raise UpdateFailed("Forbidden: Invalid Partner ID.")
@@ -101,16 +93,19 @@ class LocalvoltsDataUpdateCoordinator(DataUpdateCoordinator):
 
                 # If the API returns an empty list, log a warning
                 if isinstance(data, list) and not data:
-                    _LOGGER.warning("No data received, check that your NMI, PartnerID and API Key are correct.")
+                    _LOGGER.warning(
+                        "No data received, check that your NMI, PartnerID and API Key are correct.")
                     raise UpdateFailed("No data received: Invalid NMI?")
-            
-            
+
             except aiohttp.ClientError as e:
-                _LOGGER.error("Failed to fetch data from Localvolts API: %s", str(e))
+                _LOGGER.error(
+                    "Failed to fetch data from Localvolts API: %s", str(e))
                 raise UpdateFailed(f"Error communicating with API: {e}") from e
 
             # Process data
             new_data_found = False
+            # Clear existing forecast data to prevent duplicates
+            self.forecast_data.clear()
             for item in data:
                 if item.get("quality", "").lower() == "exp":
                     interval_end = parser.isoparse(item["intervalEnd"])
@@ -120,14 +115,16 @@ class LocalvoltsDataUpdateCoordinator(DataUpdateCoordinator):
                     if interval_end.tzinfo is None:
                         interval_end = interval_end.replace(tzinfo=tz.UTC)
                     if last_update_time.tzinfo is None:
-                        last_update_time = last_update_time.replace(tzinfo=tz.UTC)
+                        last_update_time = last_update_time.replace(
+                            tzinfo=tz.UTC)
 
                     # Update variables
                     self.intervalEnd = interval_end
                     self.lastUpdate = last_update_time
                     self.data = item
 
-                    interval_start: datetime.datetime = interval_end - datetime.timedelta(minutes=5)
+                    interval_start: datetime.datetime = interval_end - \
+                        datetime.timedelta(minutes=5)
                     self.time_past_start = last_update_time - interval_start
                     _LOGGER.debug(
                         "Data updated: intervalEnd=%s, lastUpdate=%s",
@@ -135,17 +132,21 @@ class LocalvoltsDataUpdateCoordinator(DataUpdateCoordinator):
                         self.lastUpdate,
                     )
                     new_data_found = True
-                    break
+                elif item.get("quality", "").lower() == "fcst":
+                    # Store forecast data
+                    self.forecast_data.append(item)
+                    _LOGGER.debug(
+                        "Stored forecast data: intervalEnd=%s", item["intervalEnd"])
                 else:
                     _LOGGER.debug(
-                        "Skipping non-'exp' quality data. Only 'exp' is processed."
+                        "Skipping non-'exp' and non-'fcst' quality data. Only 'exp' and 'fcst' are processed."
                     )
-            if not new_data_found:
-                _LOGGER.debug("No new data with 'exp' quality found. Retaining last known data.")
-                # Do not update self.time_past_start; retain the last known value
-                # Optionally, you can log the time since the last update if needed
         else:
             _LOGGER.debug("Data did not change. Still in the same interval.")
 
-        # Return self.data to comply with DataUpdateCoordinator requirements
-        return self.data
+        # Return both exp data and forecast data
+        # The coordinator will make this available to sensors
+        return {
+            "exp": self.data,
+            "fcst": self.forecast_data
+        }

--- a/custom_components/localvolts/sensor.py
+++ b/custom_components/localvolts/sensor.py
@@ -1,9 +1,10 @@
-"""Platform for Localvolts sensor integration."""
+"""Platform for Localvolts sensor integration. August 2025"""
 
 from __future__ import annotations
 
 import logging
 from typing import Any
+from datetime import datetime, timedelta
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -25,7 +26,6 @@ EARNINGS_FLEX_UP = "earningsFlexUp"
 
 _LOGGER = logging.getLogger(__name__)
 
-
 async def async_setup_entry(
     hass: HomeAssistant,
     config_entry: ConfigEntry,
@@ -40,6 +40,7 @@ async def async_setup_entry(
             LocalvoltsEarningsFlexUpSensor(coordinator),
             LocalvoltsDataLagSensor(coordinator),
             LocalvoltsIntervalEndSensor(coordinator),
+            LocalvoltsForecastCostsSensor(coordinator),
         ]
     )
 
@@ -53,10 +54,14 @@ class LocalvoltsSensor(CoordinatorEntity, SensorEntity):
         self._attr_should_poll = False
         self._last_value = None
 
+class LocalvoltsPriceSensor(LocalvoltsSensor):
+    """LocalVolts Price Sensor"""
+
     @property
     def native_value(self):
         """Return the state of the sensor (scaled monetary value)."""
-        item = self.coordinator.data
+        # Access the 'exp' dict if present, else fallback to previous behavior
+        item = self.coordinator.data.get("exp", self.coordinator.data)
         if item:
             value = item.get(self.data_key)
             if value is not None:
@@ -73,8 +78,7 @@ class LocalvoltsSensor(CoordinatorEntity, SensorEntity):
             "lastUpdate": last_update.isoformat() if last_update else None,
         }
 
-
-class LocalvoltsCostsFlexUpSensor(LocalvoltsSensor):
+class LocalvoltsCostsFlexUpSensor(LocalvoltsPriceSensor):
     """Sensor for monitoring costsFlexUp."""
 
     _attr_native_unit_of_measurement = "$/kWh"
@@ -82,8 +86,9 @@ class LocalvoltsCostsFlexUpSensor(LocalvoltsSensor):
 
     def __init__(self, coordinator: LocalvoltsDataUpdateCoordinator) -> None:
         super().__init__(coordinator, COSTS_FLEX_UP)
-        self._attr_name = COSTS_FLEX_UP
-        self._attr_unique_id = f"{coordinator.nmi_id}_{COSTS_FLEX_UP}"
+        # {{change 1}}
+        self._attr_name = "costsFlexUp"
+        self._attr_unique_id = f"localvolts_{coordinator.nmi_id}_costsflexup"
 
     @property
     def extra_state_attributes(self):
@@ -94,8 +99,7 @@ class LocalvoltsCostsFlexUpSensor(LocalvoltsSensor):
             attributes["demandInterval"] = demand_interval
         return attributes
 
-
-class LocalvoltsEarningsFlexUpSensor(LocalvoltsSensor):
+class LocalvoltsEarningsFlexUpSensor(LocalvoltsPriceSensor):
     """Sensor for monitoring earningsFlexUp."""
 
     _attr_native_unit_of_measurement = "$/kWh"
@@ -103,9 +107,9 @@ class LocalvoltsEarningsFlexUpSensor(LocalvoltsSensor):
 
     def __init__(self, coordinator: LocalvoltsDataUpdateCoordinator) -> None:
         super().__init__(coordinator, EARNINGS_FLEX_UP)
-        self._attr_name = EARNINGS_FLEX_UP
-        self._attr_unique_id = f"{coordinator.nmi_id}_{EARNINGS_FLEX_UP}"
-
+        # {{change 2}}
+        self._attr_name = "earningsFlexUp"
+        self._attr_unique_id = f"localvolts_{coordinator.nmi_id}_earningsflexup"
 
 class LocalvoltsDataLagSensor(CoordinatorEntity, SensorEntity):
     """Sensor for monitoring the data lag time in seconds."""
@@ -115,8 +119,9 @@ class LocalvoltsDataLagSensor(CoordinatorEntity, SensorEntity):
 
     def __init__(self, coordinator: LocalvoltsDataUpdateCoordinator) -> None:
         super().__init__(coordinator)
+        # {{change 3}}
         self._attr_name = "DataLag"
-        self._attr_unique_id = f"{coordinator.nmi_id}_data_lag"
+        self._attr_unique_id = f"localvolts_{coordinator.nmi_id}_datalag"
         self._attr_should_poll = False
 
     @property
@@ -135,7 +140,6 @@ class LocalvoltsDataLagSensor(CoordinatorEntity, SensorEntity):
             "lastUpdate": last_update.isoformat() if last_update else None,
         }
 
-
 class LocalvoltsIntervalEndSensor(CoordinatorEntity, SensorEntity):
     """Sensor for monitoring the end time of the latest interval."""
 
@@ -143,8 +147,9 @@ class LocalvoltsIntervalEndSensor(CoordinatorEntity, SensorEntity):
 
     def __init__(self, coordinator: LocalvoltsDataUpdateCoordinator) -> None:
         super().__init__(coordinator)
+        # {{change 4}}
         self._attr_name = "IntervalEnd"
-        self._attr_unique_id = f"{coordinator.nmi_id}_interval_end"
+        self._attr_unique_id = f"localvolts_{coordinator.nmi_id}_intervalend"
         self._attr_should_poll = False
 
     @property
@@ -155,24 +160,79 @@ class LocalvoltsIntervalEndSensor(CoordinatorEntity, SensorEntity):
     @property
     def extra_state_attributes(self):
         """
-        Return all available interval fields as attributes.
-
-        This method copies every key/value pair from the coordinator's data dictionary,
-        converting any datetime objects to ISO strings for readability.  It then adds
-        the `lastUpdate` and `intervalEnd` timestamps (converted to ISO strings) so
-        that these are always present.
+        Return limited attributes to avoid exceeding size limits.
+        
+        Only include essential fields to prevent database performance issues.
         """
         attrs: dict[str, Any] = {}
-        data = getattr(self.coordinator, "data", {}) or {}
-        # Copy all fields from the data record
-        for key, value in data.items():
-            if hasattr(value, "isoformat"):
-                attrs[key] = value.isoformat()
-            else:
-                attrs[key] = value
-        # Ensure lastUpdate and intervalEnd are included as ISO strings
-        if getattr(self.coordinator, "lastUpdate", None):
-            attrs["lastUpdate"] = self.coordinator.lastUpdate.isoformat()
-        if getattr(self.coordinator, "intervalEnd", None):
+        
+        # Only include critical fields that are needed
+        if self.coordinator.intervalEnd:
             attrs["intervalEnd"] = self.coordinator.intervalEnd.isoformat()
+            
+        if self.coordinator.lastUpdate:
+            attrs["lastUpdate"] = self.coordinator.lastUpdate.isoformat()
+            
+        # Only include a few key fields from data, not all of them
+        data = getattr(self.coordinator, "data", {})
+        critical_fields = ["costsFlexUp", "earningsFlexUp", "demandInterval", "intervalStart"]
+        
+        for field in critical_fields:
+            if field in data:
+                value = data[field]
+                if hasattr(value, "isoformat"):
+                    attrs[field] = value.isoformat()
+                else:
+                    attrs[field] = value
+                    
         return attrs
+
+class LocalvoltsForecastCostsSensor(CoordinatorEntity, SensorEntity):
+    """Sensor for monitoring forecasted costsFlexUp for the next 24 hours."""
+
+    _attr_native_unit_of_measurement = "c/kWh"
+    _attr_device_class = SensorDeviceClass.MONETARY
+    _attr_name = "Forecasted Costs Flex Up"
+
+    def __init__(self, coordinator: LocalvoltsDataUpdateCoordinator) -> None:
+        super().__init__(coordinator)
+        self._attr_name = "Forecasted Costs Flex Up"
+        self._attr_unique_id = f"{coordinator.nmi_id}_forecast_costs_flex_up"
+        self._attr_should_poll = False
+
+    @property
+    def native_value(self):
+        """Return the state of the sensor (cents per kWh)."""
+        if not self.coordinator.forecast_data:
+            return None
+
+        # Get the most recent forecast data
+        latest_forecast = max(self.coordinator.forecast_data,
+                              key=lambda x: x["intervalEnd"])
+        value = latest_forecast.get("costsFlexUp")
+        if value is not None:
+            return round(value, 3)
+        return None
+
+    @property
+    def extra_state_attributes(self):
+        attributes = {}
+        forecast = []
+        if self.coordinator.forecast_data:
+            for fcast in self.coordinator.forecast_data:
+                try:
+                    interval_end_dt = datetime.fromisoformat(fcast["intervalEnd"].replace("Z", "+00:00"))
+                    duration = int(fcast.get("intervalDuration", 5))
+                    start_time_dt = interval_end_dt - timedelta(minutes=duration)
+                    forecast.append({
+                        "duration": duration,
+                        "start_time": start_time_dt.isoformat(),
+                        "end_time": interval_end_dt.isoformat(),
+                        "earningsFlexUp": round(fcast.get("earningsFlexUp", 0), 5),
+                        "costsFlexUp": round(fcast.get("costsFlexUp", 0), 5)
+                    })
+                except Exception:
+                    continue
+            attributes["forecast"] = forecast
+            attributes["forecastcount"] = len(forecast)
+        return attributes


### PR DESCRIPTION
forecasted_costs_flex_up state reflects current costsFlexUp in c/kWh. State attributes capture 5 minute forcasts for earningFlexUp and costsFlexUp in c/kWh. Also captures forcastcount (total forecasts in list)

```
forecast:
  - duration: 5
    start_time: "2025-09-01T21:55:00+00:00"
    end_time: "2025-09-01T22:00:00+00:00"
    earningsFlexUp: 22.65218
    costsFlexUp: 32.34263
  - duration: 5
    start_time: "2025-09-01T22:00:00+00:00"
    end_time: "2025-09-01T22:05:00+00:00"
    earningsFlexUp: 20.38499
    costsFlexUp: 29.84872
  ...
  - duration: 5
    start_time: '2025-09-02T21:50:00+00:00'
    end_time: '2025-09-02T21:55:00+00:00'
    earningsFlexUp: 12.81728
    costsFlexUp: 21.52423
  forecastcount: 287
  unit_of_measurement: c/kWh
  device_class: monetary
  friendly_name: Forecasted Costs Flex Up
  ...
  - duration: 5
    start_time: '2025-09-02T21:50:00+00:00'
    end_time: '2025-09-02T21:55:00+00:00'
    earningsFlexUp: 12.81728
    costsFlexUp: 21.52423

  forecastcount: 287
  unit_of_measurement: c/kWh
  device_class: monetary
  friendly_name: Forecasted Costs Flex Up
```